### PR TITLE
feat: setup env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+APP_ENV=development

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-node-resolve": "^14.1.0",
+        "@rollup/plugin-replace": "^5.0.0",
         "@types/node": "^17.0.21",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
@@ -331,6 +332,52 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.0.tgz",
+      "integrity": "sha512-TiPmjMuBjQM+KLWK16O5TAM/eW4yXBYyQ17FbfeNzBC1t2kzX2aXoa8AlS9XTSmg6/2TNvkER1lMEEeN4Lhavw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.2.1",
+        "magic-string": "^0.26.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -4305,6 +4352,37 @@
         "is-builtin-module": "^3.1.0",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.0.tgz",
+      "integrity": "sha512-TiPmjMuBjQM+KLWK16O5TAM/eW4yXBYyQ17FbfeNzBC1t2kzX2aXoa8AlS9XTSmg6/2TNvkER1lMEEeN4Lhavw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.2.1",
+        "magic-string": "^0.26.4"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "magic-string": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+          "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
+    "@rollup/plugin-replace": "^5.0.0",
     "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,6 +5,8 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import del from 'rollup-plugin-delete';
 import { serve } from './src/scripts/reload-server.js';
+import replace from '@rollup/plugin-replace';
+import dotenv from 'dotenv';
 
 const packageJson = JSON.parse(
   readFileSync(new URL('package.json', import.meta.url))
@@ -53,7 +55,14 @@ export default [
         targets: 'build/__client'
       }),
       nodeResolve(),
-      commonjs()
+      commonjs(),
+      replace({
+        process: JSON.stringify({
+          env: {
+            ...dotenv.config().parsed
+          }
+        })
+      })
     ],
     watch: {
       chokidar: {},

--- a/src/ssr/server/page-loader.js
+++ b/src/ssr/server/page-loader.js
@@ -58,10 +58,7 @@ const readPagesRecursive = async (fastify, rootPath, currentPath) => {
           if (individualPath === 'index') {
             splitPath.pop();
             pathCounter--;
-            individualPath = splitPath[pathCounter];
-          }
-
-          if (
+          } else if (
             individualPath[0] === '_' &&
             individualPath[individualPath.length - 1] === '_'
           ) {
@@ -71,8 +68,10 @@ const readPagesRecursive = async (fastify, rootPath, currentPath) => {
             );
             splitPath[pathCounter] = `:${individualPath}`;
             pathCounter--;
+          } else {
+            pathCounter--;
           }
-        } while (pathCounter > 1);
+        } while (pathCounter > 0);
 
         urlpath = splitPath.join('/');
         urlpath = urlpath ? urlpath : '/';


### PR DESCRIPTION
# Description
This PR will enable us to store the environment variables on the `.env` file and access it using `process.env` syntax. Currently,`process.env` can only be accessed on the server-side only. This means, the `process.env` cannot be accessed directly on the lit component.

Example usage:
```js
export const getServerSideProps = () => {
  const appEnv = process.env.APP_ENV;

  console.log(appEnv);

  return {
    props: {
      appEnv: appEnv
    }
  };
};
```

Based on the example above, we can get the `APP_ENV` environment variable by accessing it through `process.env.APP_ENV ` inside the `getServerSideProps` function.

Another thing I need to mention that this PR also fixes infinite loop when we define a regular page that is not either index.js file or a dynamic page (page with bracket [])