### PR TITLE
feat: viewer watching page

### DIFF
--- a/src/features/shared/ui/app-lozenge.js
+++ b/src/features/shared/ui/app-lozenge.js
@@ -1,0 +1,42 @@
+import { css, html, LitElement } from 'lit';
+
+class AppLozenge extends LitElement {
+  static styles = css`
+    :host {
+      --border-radius: 0.25rem;
+      --background-color: #111827;
+      --color: #fff;
+      --font-size: 0.875rem;
+      --font-weight: 500;
+      --line-height: 1.25rem;
+      --padding-right: 0.75rem;
+      --padding-left: 0.75rem;
+      --padding-top: 0.125rem;
+      --padding-bottom: 0.125rem;
+      --padding: var(--padding-top) var(--padding-right) var(--padding-bottom)
+        var(--padding-left);
+    }
+
+    .lozenge {
+      display: inline-block;
+      border-radius: var(--border-radius);
+      padding: var(--padding);
+      background-color: var(--background-color);
+      color: var(--color);
+      font-size: var(--font-size);
+      font-weight: var(--font-weight);
+      line-height: var(--line-height);
+      font-variant-numeric: tabular-nums;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="lozenge">
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+customElements.define('app-lozenge', AppLozenge);

--- a/src/features/shared/ui/app-viewer-count.js
+++ b/src/features/shared/ui/app-viewer-count.js
@@ -1,0 +1,87 @@
+import { html, LitElement, css } from 'lit';
+
+class AppViewerCount extends LitElement {
+  static styles = css`
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    .viewer-count {
+      display: flex;
+      align-items: center;
+      background-color: #111827;
+      border-radius: 0.25rem;
+      padding: 0.125rem 0.5rem;
+    }
+
+    .viewer-count-icon {
+      display: flex;
+      align-items: center;
+      margin-right: 0.5rem;
+    }
+
+    .viewer-count-text-wrapper {
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+    }
+
+    .viewer-count-number {
+      font-variant-numeric: tabular-nums;
+    }
+
+    .viewer-count-text {
+      display: none;
+    }
+
+    .icon {
+      width: 1rem;
+      height: 1rem;
+    }
+
+    @media (min-width: 1024px) {
+      .viewer-count {
+        color: #475569;
+        background-color: transparent;
+      }
+
+      .viewer-count-text {
+        display: inline-block;
+      }
+
+      .icon {
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="viewer-count">
+        <div class="viewer-count-icon">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="icon"
+          >
+            <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+            <path
+              fill-rule="evenodd"
+              d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 010-1.113zM17.25 12a5.25 5.25 0 11-10.5 0 5.25 5.25 0 0110.5 0z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <p class="viewer-count-text-wrapper">
+          <span class="viewer-count-number">0</span>
+          <span class="viewer-count-text">watching now</span>
+        </p>
+      </div>
+    `;
+  }
+}
+
+customElements.define('app-viewer-count', AppViewerCount);

--- a/src/features/viewer/room/app-activity-panel.js
+++ b/src/features/viewer/room/app-activity-panel.js
@@ -1,0 +1,152 @@
+import { css, html, LitElement } from 'lit';
+
+class AppActivityPanel extends LitElement {
+  static styles = css`
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    :host {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .activity-panel-heading {
+      display: none;
+      border-top: 1px solid #d1d5db;
+      border-bottom: 1px solid #d1d5db;
+      padding: 0.5rem;
+      font-weight: 600;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      color: #4b5563;
+      background-color: white;
+    }
+
+    .activity-panel-body {
+      flex: 1;
+      background-color: transparent;
+    }
+
+    .activity-panel-list {
+      display: flex;
+      flex-direction: column;
+      list-style: none;
+      padding: 0.5rem 0;
+    }
+
+    .activity-log,
+    .activity-chat {
+      margin-bottom: 0.5rem;
+    }
+
+    .activity-log-message {
+      display: inline-flex;
+      padding: 0.125rem 0.5rem;
+      background-color: rgba(0, 0, 0, 0.3);
+      border-radius: 0.5rem;
+      font-size: 0.75rem;
+      line-height: 1rem;
+    }
+
+    .activity-chat-wrapper {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      background-color: rgba(0, 0, 0, 0.3);
+      border-radius: 0.5rem;
+      font-size: 0.75rem;
+      line-height: 1rem;
+    }
+
+    .activity-chat-name {
+      font-weight: 600;
+      color: #f9fafb;
+    }
+
+    .activity-chat-message {
+      margin-left: 0.25rem;
+    }
+
+    @media (min-width: 1024px) {
+      :host {
+        background-color: #f9fafb;
+      }
+
+      .activity-panel-heading {
+        display: block;
+      }
+
+      .activity-log {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 0.5rem;
+      }
+
+      .activity-log-message {
+        background-color: #e5e7eb;
+        color: #4b5563;
+        letter-spacing: 0.1px;
+        text-align: center;
+      }
+
+      .activity-chat {
+        margin-bottom: 0.75rem;
+        padding: 0 0.5rem;
+      }
+
+      .activity-chat-wrapper {
+        padding: 0;
+        background-color: transparent;
+        border-radius: 0;
+      }
+
+      .activity-chat-name {
+        color: #1f2937;
+        font-weight: 600;
+      }
+
+      .activity-chat-message {
+        color: #1f2937;
+      }
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="activity-panel-heading">Stream Activity</div>
+      <div class="activity-panel-body">
+        <ul class="activity-panel-list">
+          <li class="activity-log">
+            <p class="activity-log-message">luffy joined</p>
+          </li>
+          <li class="activity-log">
+            <p class="activity-log-message">zoro joined</p>
+          </li>
+          <li class="activity-chat">
+            <div class="activity-chat-wrapper">
+              <strong class="activity-chat-name">luffy:</strong>
+              <p class="activity-chat-message">seru banget!!!</p>
+            </div>
+          </li>
+          <li class="activity-log">
+            <p class="activity-log-message">zoro joined</p>
+          </li>
+          <li class="activity-chat">
+            <div class="activity-chat-wrapper">
+              <strong class="activity-chat-name">luffy:</strong>
+              <p class="activity-chat-message">seru banget!!!</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+      <div class="activity-panel-footer"></div>
+    `;
+  }
+}
+
+customElements.define('app-activity-panel', AppActivityPanel);

--- a/src/features/viewer/room/app-information-panel.js
+++ b/src/features/viewer/room/app-information-panel.js
@@ -1,0 +1,116 @@
+import { html, LitElement, css } from 'lit';
+import '../../shared/ui/app-viewer-count.js';
+import '../../shared/ui/app-lozenge.js';
+
+class AppInformationPanel extends LitElement {
+  static styles = css`
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    .information-panel {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+
+    .heading {
+      font-weight: 600;
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
+
+    .truncate {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .description {
+      display: none;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      color: #6b7280;
+    }
+    .status-panel {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 0.25rem;
+    }
+
+    .lozenge-live-status {
+      display: flex;
+      column-gap: 0.25rem;
+    }
+
+    .lozenge-live {
+      --background-color: #dc2626;
+      --color: #fff;
+      --font-weight: 700;
+    }
+
+    .lozenge-ended {
+      --background-color: #f3f4f6;
+      --color: #1f2937;
+    }
+
+    @media (min-width: 1024px) {
+      .information-panel {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 5rem;
+      }
+
+      .heading {
+        order: 2;
+        color: #1f2937;
+        font-size: 1.25rem;
+        line-height: 1.75rem;
+        font-weight: 700;
+        margin-top: 1rem;
+      }
+
+      .description {
+        order: 3;
+        display: inline-block;
+      }
+
+      .status-panel {
+        order: 1;
+        margin-top: 1rem;
+      }
+    }
+  `;
+
+  static properties = {
+    heading: { type: String },
+    description: { type: String }
+  };
+
+  constructor() {
+    super();
+    this.heading = '';
+    this.description = '';
+  }
+
+  render() {
+    return html`
+      <div class="information-panel">
+        <h1 class="heading truncate">${this.heading}</h1>
+        ${this.description
+          ? html` <p class="description">${this.description}</p> `
+          : undefined}
+        <div class="status-panel">
+          <div class="lozenge-live-status">
+            <app-lozenge class="lozenge-live">LIVE</app-lozenge>
+            <app-lozenge>00:12:34</app-lozenge>
+          </div>
+          <app-viewer-count></app-viewer-count>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('app-information-panel', AppInformationPanel);

--- a/src/features/viewer/room/app-video-panel.js
+++ b/src/features/viewer/room/app-video-panel.js
@@ -1,0 +1,53 @@
+import { html, LitElement, css } from 'lit';
+import '../../player/app-player.js';
+
+class AppVideoPanel extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      height: 100%;
+    }
+
+    .container {
+      flex: 1;
+      background-color: #555;
+    }
+
+    @media (min-width: 1024px) {
+      .container {
+        overflow: hidden;
+        border-radius: 1rem;
+      }
+    }
+  `;
+
+  static properties = {
+    hlsManifest: { type: String },
+    dashManifest: { type: String }
+  };
+
+  constructor() {
+    super();
+    this.hlsManifest = '';
+    this.dashManifest = '';
+  }
+
+  render() {
+    return html`
+      <div class="container">
+        <app-player
+          class="ratio-16-9"
+          src=${this.hlsManifest}
+          dashUrl=${this.dashManifest}
+          hlsUrl=${this.hlsManifest}
+          autoplay
+          muted
+        ></app-player>
+      </div>
+    `;
+  }
+}
+
+customElements.define('app-video-panel', AppVideoPanel);

--- a/src/features/viewer/room/app-viewer-room.js
+++ b/src/features/viewer/room/app-viewer-room.js
@@ -1,0 +1,130 @@
+import { css, html, LitElement } from 'lit';
+import './app-video-panel.js';
+import './app-information-panel.js';
+import './app-activity-panel.js';
+
+class AppViewerRoom extends LitElement {
+  static styles = css`
+    .main-panel {
+      position: relative;
+      min-height: 100vh;
+      background-color: #000;
+      color: #fff;
+      display: grid;
+      grid-template-areas:
+        'information-panel'
+        '.'
+        'activity-panel';
+      grid-template-rows: max-content auto max-content;
+      grid-template-columns: 1fr;
+    }
+
+    .video-panel {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      grid-area: video-panel;
+    }
+
+    .information-panel {
+      position: relative;
+      margin-top: 3rem;
+      grid-area: information-panel;
+      overflow-x: hidden;
+    }
+
+    .activity-panel {
+      position: relative;
+      grid-area: activity-panel;
+    }
+
+    @media (min-width: 1024px) {
+      .main-panel {
+        background-color: #fff;
+        color: #000;
+        grid-template-areas:
+          'video-panel activity-panel'
+          'information-panel activity-panel';
+        grid-template-columns: auto 20rem;
+        grid-template-rows: max-content auto;
+      }
+
+      .video-panel {
+        position: unset;
+        top: unset;
+        left: unset;
+        width: auto;
+        height: auto;
+        padding: 1.5rem 1.5rem 0 1.5rem;
+      }
+
+      .information-panel {
+        margin-top: 0;
+      }
+
+      .activity-panel-container {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 20rem;
+        height: 100%;
+        max-height: 100vh;
+        border-left: 1px solid #d1d5db;
+      }
+    }
+
+    @media (min-width: 1280px) {
+      .main-panel {
+        grid-template-columns: auto 23rem;
+      }
+
+      .activity-panel-container {
+        width: 23rem;
+      }
+    }
+  `;
+
+  static properties = {
+    heading: { type: String },
+    description: { type: String },
+    hlsManifest: { type: String },
+    dashManifest: { type: String }
+  };
+
+  constructor() {
+    super();
+    this.heading = '';
+    this.description = '';
+    this.hlsManifest = '';
+    this.dashManifest = '';
+  }
+
+  render() {
+    return html`
+      <div class="main-panel">
+        <div class="video-panel">
+          <app-video-panel
+            hlsManifest=${this.hlsManifest}
+            dashManifest=${this.dashManifest}
+          ></app-video-panel>
+        </div>
+        <div class="information-panel">
+          <app-information-panel
+            heading=${this.heading}
+            description=${this.description}
+          ></app-information-panel>
+        </div>
+        <div class="activity-panel">
+          <div class="activity-panel-container">
+            <app-activity-panel></app-activity-panel>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('app-viewer-room', AppViewerRoom);

--- a/src/pages/streaming/watch/[streamid].js
+++ b/src/pages/streaming/watch/[streamid].js
@@ -1,0 +1,41 @@
+import { html } from 'lit';
+import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+
+const WatchStreamingPage = (properties) => {
+  const { heading, description, hlsManifest, dashManifest } = properties;
+
+  return html`
+    <app-viewer-room
+      heading=${heading}
+      description=${description}
+      hlsManifest=${hlsManifest}
+      dashManifest=${dashManifest}
+    >
+    </app-viewer-room>
+  `;
+};
+
+export const scripts = `
+  <script type="module" src="/__client/features/viewer/room/app-viewer-room.js"></script>
+`;
+
+export default WatchStreamingPage;
+
+export const getServerSideProps = async (request) => {
+  const streamId = Number.parseInt(request.params.streamid, 10);
+  const streamResponse = await InliveStream.getStream(streamId);
+  let streamData = {};
+
+  if (streamResponse.status.code === 200 && streamResponse.data) {
+    streamData = streamResponse.data;
+  }
+
+  return {
+    props: {
+      heading: streamData.name || '',
+      description: streamData.description || '',
+      hlsManifest: streamData.hls_manifest_path || '',
+      dashManifest: streamData.dash_manifest_path || ''
+    }
+  };
+};


### PR DESCRIPTION
# Description
This PR relates this issue #16. This PR will enable a page that can be used by other users to watch the live streaming session from a specific streamer. 

- The page can be accessed through the URL `/streaming/watch/{STREAM_ID}`
- The video player we currently use to play the DASH or HLS formats is [shaka-player](https://github.com/shaka-project/shaka-player).
- The viewer page consists of three main panels:
   - Video panel: panel that displays the video player plays the live streaming video broadcasted by the streamer
   - Information panel: the panel that displays the information data about the specific stream such as the stream title and description.
   - Activity panel: the panel that displays the activity log from the user. This is just UI only for now and is still not usable.

Additional things:
- Create lozenge UI component
- Create a viewer counter UI component. This is just the UI and the component is still not usable for now.