### PR TITLE
fix: fetch http uncaught error

### DIFF
--- a/src/features/shared/modules/fetch-http.js
+++ b/src/features/shared/modules/fetch-http.js
@@ -77,7 +77,7 @@ export const fetchHttp = async (config = baseConfig) => {
   const response = await fetchHttpRequest(url, options);
   const json = await response.json();
 
-  return response.ok && json.code >= 200 && json.code < 300
+  return response.ok && response.status >= 200 && response.status < 300
     ? Promise.resolve(json)
     : Promise.reject(json);
 };

--- a/src/features/shared/modules/fetch-http.js
+++ b/src/features/shared/modules/fetch-http.js
@@ -74,8 +74,18 @@ export const fetchHttp = async (config = baseConfig) => {
     };
   }
 
+  /** @type {Response} */
   const response = await fetchHttpRequest(url, options);
-  const json = await response.json();
+  const contentType = response.headers.get('content-type');
+
+  let json = {};
+
+  if (contentType && contentType.includes('application/json')) {
+    json = await response.json();
+  } else {
+    const text = await response.text();
+    json = { data: text };
+  }
 
   return response.ok && response.status >= 200 && response.status < 300
     ? Promise.resolve(json)


### PR DESCRIPTION
# Description
This will fix the these uncaught error on fetch-http module.
1. Fix uncaught error when the content-type is not `application/json` which means the data is probably a string/text.
2. Fix uncaught error on `json.code` which is not reliable and can be wrong if checking it from the actual json data. To check the HTTP status code, we will use more reliable method by using `response.ok` & `response.status`