### PR TITLE
Feat : Timer Counter

### DIFF
--- a/src/features/shared/modules/handle-timer.js
+++ b/src/features/shared/modules/handle-timer.js
@@ -12,8 +12,8 @@ export const handleTimer = (
   if (streamStatus === 'live' && appTimerCounter) {
     //when the stream is live but the user just reload the page, the timer will get the time when the stream started
     if (startTime) {
-      const timeStartTime = new Date(startTime).getTime();
-      appTimerCounter.handleStartTimer(timeStartTime);
+      const startTimeInNumber = new Date(startTime).getTime();
+      appTimerCounter.handleStartTimer(startTimeInNumber);
     } else {
       //we don't need start time param when the stream is just started to live
       appTimerCounter.handleStartTimer();
@@ -23,17 +23,17 @@ export const handleTimer = (
 
     //when loaded on first time, if the stream has already ended, will get the previous stream duration
     if (startTime && endTime) {
-      const timeStartTime = new Date(startTime).getTime();
-      const timeEndTime = new Date(endTime).getTime();
-      const substractTime = timeEndTime - timeStartTime;
+      const startTimeInNumber = new Date(startTime).getTime();
+      const endTimeInNumber = new Date(endTime).getTime();
+      const substractTime = endTimeInNumber - startTimeInNumber;
       appTimerCounter.handleFormatTime(substractTime);
     }
 
     //when loaded on first time, if the stream hasn't ended yet (still on going), will get the stream duration up until now
     if (startTime && !endTime) {
-      const timeStartTime = new Date(startTime).getTime();
+      const startTimeInNumber = new Date(startTime).getTime();
       const timeNow = Date.now();
-      const substractTime = timeNow - timeStartTime;
+      const substractTime = timeNow - startTimeInNumber;
       appTimerCounter.handleFormatTime(substractTime);
     }
   }

--- a/src/features/shared/modules/handle-timer.js
+++ b/src/features/shared/modules/handle-timer.js
@@ -1,0 +1,40 @@
+/**
+ * @type {any}
+ */
+export const handleTimer = (
+  /** @type {{ handleStartTimer: (arg0: number | undefined) => void; handleEndTimer: () => void; handleFormatTime: (arg0: number) => void; }} */ appTimerCounter,
+  /** @type {string} */ streamStatus,
+  /** @type {string | number | Date} */ startTime,
+  /** @type {string | number | Date} */ endTime
+) => {
+  // const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
+
+  if (streamStatus === 'live' && appTimerCounter) {
+    //when the stream is live but the user just reload the page, the timer will get the time when the stream started
+    if (startTime) {
+      const timeStartTime = new Date(startTime).getTime();
+      appTimerCounter.handleStartTimer(timeStartTime);
+    } else {
+      //we don't need start time param when the stream is just started to live
+      appTimerCounter.handleStartTimer();
+    }
+  } else if (streamStatus === 'end' && appTimerCounter) {
+    appTimerCounter.handleEndTimer();
+
+    //when loaded on first time, if the stream has already ended, will get the previous stream duration
+    if (startTime && endTime) {
+      const timeStartTime = new Date(startTime).getTime();
+      const timeEndTime = new Date(endTime).getTime();
+      const substractTime = timeEndTime - timeStartTime;
+      appTimerCounter.handleFormatTime(substractTime);
+    }
+
+    //when loaded on first time, if the stream hasn't ended yet (still on going), will get the stream duration up until now
+    if (startTime && !endTime) {
+      const timeStartTime = new Date(startTime).getTime();
+      const timeNow = Date.now();
+      const substractTime = timeNow - timeStartTime;
+      appTimerCounter.handleFormatTime(substractTime);
+    }
+  }
+};

--- a/src/features/shared/ui/app-timer-counter.js
+++ b/src/features/shared/ui/app-timer-counter.js
@@ -42,8 +42,8 @@ class AppTimerCounter extends LitElement {
   }
 
   /**
-   * @param {any} timestamp time stamp
-   * @returns {any} formatTime
+   * @param {number} timestamp time stamp
+   * @returns {string} format time in hh:mm:ss
    */
   handleFormatTime(timestamp) {
     let hours = Math.floor(

--- a/src/features/shared/ui/app-timer-counter.js
+++ b/src/features/shared/ui/app-timer-counter.js
@@ -1,0 +1,83 @@
+import { LitElement } from 'lit';
+
+class AppTimerCounter extends LitElement {
+  static properties = {
+    duration: { type: String },
+    start: { type: Boolean },
+    startTime: { type: Number },
+    endTime: { type: Number },
+    _interval: { state: true }
+  };
+
+  constructor() {
+    super();
+    this.duration = '00:00:00';
+    this.start = false;
+    this.startTime = 0;
+    this.endTime = 0;
+    this._interval = undefined;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearInterval(this._interval);
+    this.start = false;
+  }
+
+  /**
+   * @param {number} startTimeStamp start time stamp
+   */
+  handleStartTimer(startTimeStamp) {
+    if (!this.start) {
+      this.start = true;
+      const startTime = startTimeStamp || Date.now();
+      this.startTime = startTime;
+
+      this._interval = setInterval(() => {
+        const currentTime = Date.now();
+        const substractTime = currentTime - startTime;
+        this.handleFormatTime(substractTime);
+      }, 100);
+    }
+  }
+
+  /**
+   * @param {any} timestamp time stamp
+   * @returns {any} formatTime
+   */
+  handleFormatTime(timestamp) {
+    let hours = Math.floor(
+      (timestamp % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+    );
+    let minutes = Math.floor((timestamp % (1000 * 60 * 60)) / (1000 * 60));
+    let seconds = Math.floor((timestamp % (1000 * 60)) / 1000);
+
+    hours = hours.toString();
+    hours = hours.length === 1 ? '0' + hours : hours;
+
+    minutes = minutes.toString();
+    minutes = minutes.length === 1 ? '0' + minutes : minutes;
+
+    seconds = seconds.toString();
+    seconds = seconds.length === 1 ? '0' + seconds : seconds;
+
+    const formatTime = `${hours}:${minutes}:${seconds}`;
+    this.duration = formatTime;
+
+    return formatTime;
+  }
+
+  handleEndTimer() {
+    if (this.start) {
+      this.endTime = Date.now();
+      clearInterval(this._interval);
+      this.start = false;
+    }
+  }
+
+  render() {
+    return this.duration;
+  }
+}
+
+customElements.define('app-timer-counter', AppTimerCounter);

--- a/src/features/streamer/studio/app-information-panel.js
+++ b/src/features/streamer/studio/app-information-panel.js
@@ -2,6 +2,7 @@ import { html, LitElement, css } from 'lit';
 import '../../shared/ui/app-viewer-count.js';
 import '../../shared/ui/app-lozenge.js';
 import '../../shared/ui/app-timer-counter.js';
+import { handleTimer } from '../../shared/modules/handle-timer.js';
 
 /**
  * @typedef {import('./app-studio.js').StreamStatusType} StreamStatusType
@@ -125,26 +126,14 @@ export class AppInformationPanel extends LitElement {
   updated(changedProperties) {
     //check for the streamState changes
     if (changedProperties.has('streamStatus')) {
-      this.handleTimer();
-    }
-  }
-
-  handleTimer() {
-    const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
-
-    if (this.streamStatus === 'live' && appTimerCounter) {
-      //we don't need start time param when the stream is just started to live
-      appTimerCounter.handleStartTimer();
-    } else if (this.streamStatus === 'end' && appTimerCounter) {
-      appTimerCounter.handleEndTimer();
-
-      //when loaded on first time, if the stream has already ended, will get the previous stream duration
-      if (this.startTime && this.endTime) {
-        const startTime = new Date(this.startTime).getTime();
-        const endTime = new Date(this.endTime).getTime();
-        const substractTime = endTime - startTime;
-        appTimerCounter.handleFormatTime(substractTime);
-      }
+      const appTimerCounter =
+        this.renderRoot.querySelector('app-timer-counter');
+      handleTimer(
+        appTimerCounter,
+        this.streamStatus,
+        this.startTime,
+        this.endTime
+      );
     }
   }
 

--- a/src/features/streamer/studio/app-information-panel.js
+++ b/src/features/streamer/studio/app-information-panel.js
@@ -127,9 +127,9 @@ export class AppInformationPanel extends LitElement {
   }
 
   handleTimer() {
+    console.log('start', this.startTime);
+    console.log('end', this.endTime);
     const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
-    console.log('tes', appTimerCounter.handleStartTimer());
-    console.log('cek status', this.streamStatus);
 
     if (this.streamStatus === 'live' && appTimerCounter) {
       //when the stream is live but the user accidentally reload the page, the timer will get the time when the stream started
@@ -145,6 +145,7 @@ export class AppInformationPanel extends LitElement {
 
       //when loaded on first time, if the stream has already ended, will get the previous stream duration
       if (this.startTime && this.endTime) {
+        console.log('ada start & end time');
         const startTime = new Date(this.startTime).getTime();
         const endTime = new Date(this.endTime).getTime();
         const substractTime = endTime - startTime;
@@ -171,22 +172,21 @@ export class AppInformationPanel extends LitElement {
             ? html`
                 <app-lozenge class="lozenge-ready">Ready to Live</app-lozenge>
               `
-            : this.streamStatus === 'live'
+            : this.streamStatus === 'live' || this.streamStatus === 'end'
             ? html`
                 <div class="lozenge-wrapper">
-                  <app-lozenge class="lozenge-live">LIVE</app-lozenge>
-                  <app-lozenge
-                    ><app-timer-counter></app-timer-counter
-                  ></app-lozenge>
-                </div>
-              `
-            : this.streamStatus === 'end'
-            ? html`
-                <div class="lozenge-wrapper">
-                  <app-lozenge class="lozenge-ended">Live Ended</app-lozenge>
-                  <app-lozenge
-                    ><app-timer-counter></app-timer-counter
-                  ></app-lozenge>
+                  ${this.streamStatus === 'live'
+                    ? html`<app-lozenge class="lozenge-live">LIVE</app-lozenge>`
+                    : this.streamStatus === 'end'
+                    ? html`<app-lozenge class="lozenge-ended"
+                        >Live Ended</app-lozenge
+                      >`
+                    : undefined}
+                  ${this.streamStatus === 'live' || this.streamStatus === 'end'
+                    ? html`<app-lozenge
+                        ><app-timer-counter></app-timer-counter
+                      ></app-lozenge>`
+                    : undefined}
                 </div>
               `
             : html`

--- a/src/features/streamer/studio/app-information-panel.js
+++ b/src/features/streamer/studio/app-information-panel.js
@@ -119,33 +119,27 @@ export class AppInformationPanel extends LitElement {
     this.startTime = undefined;
   }
 
+  /**
+   * @param {{ has: (arg0: string) => any; }} changedProperties changed properties name
+   */
   updated(changedProperties) {
-    //check for the streamState changes from handleStreamState method
+    //check for the streamState changes
     if (changedProperties.has('streamStatus')) {
       this.handleTimer();
     }
   }
 
   handleTimer() {
-    console.log('start', this.startTime);
-    console.log('end', this.endTime);
     const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
 
     if (this.streamStatus === 'live' && appTimerCounter) {
-      //when the stream is live but the user accidentally reload the page, the timer will get the time when the stream started
-      if (this.startTime) {
-        const startTime = new Date(this.startTime).getTime();
-        appTimerCounter.handleStartTimer(startTime);
-      } else {
-        //we don't need start time param when the stream is just started to live
-        appTimerCounter.handleStartTimer();
-      }
+      //we don't need start time param when the stream is just started to live
+      appTimerCounter.handleStartTimer();
     } else if (this.streamStatus === 'end' && appTimerCounter) {
       appTimerCounter.handleEndTimer();
 
       //when loaded on first time, if the stream has already ended, will get the previous stream duration
       if (this.startTime && this.endTime) {
-        console.log('ada start & end time');
         const startTime = new Date(this.startTime).getTime();
         const endTime = new Date(this.endTime).getTime();
         const substractTime = endTime - startTime;

--- a/src/features/streamer/studio/app-information-panel.js
+++ b/src/features/streamer/studio/app-information-panel.js
@@ -1,6 +1,7 @@
 import { html, LitElement, css } from 'lit';
 import '../../shared/ui/app-viewer-count.js';
 import '../../shared/ui/app-lozenge.js';
+import '../../shared/ui/app-timer-counter.js';
 
 /**
  * @typedef {import('./app-studio.js').StreamStatusType} StreamStatusType
@@ -99,7 +100,9 @@ export class AppInformationPanel extends LitElement {
   static properties = {
     heading: { type: String },
     description: { type: String },
-    streamStatus: { type: String }
+    streamStatus: { type: String },
+    endTime: { type: String },
+    startTime: { type: String }
   };
 
   constructor() {
@@ -110,6 +113,44 @@ export class AppInformationPanel extends LitElement {
     this.description = '';
     /** @type {StreamStatusType} */
     this.streamStatus = 'preparing';
+    /** @type {string | undefined} */
+    this.endTime = undefined;
+    /** @type {string | undefined} */
+    this.startTime = undefined;
+  }
+
+  updated(changedProperties) {
+    //check for the streamState changes from handleStreamState method
+    if (changedProperties.has('streamStatus')) {
+      this.handleTimer();
+    }
+  }
+
+  handleTimer() {
+    const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
+    console.log('tes', appTimerCounter.handleStartTimer());
+    console.log('cek status', this.streamStatus);
+
+    if (this.streamStatus === 'live' && appTimerCounter) {
+      //when the stream is live but the user accidentally reload the page, the timer will get the time when the stream started
+      if (this.startTime) {
+        const startTime = new Date(this.startTime).getTime();
+        appTimerCounter.handleStartTimer(startTime);
+      } else {
+        //we don't need start time param when the stream is just started to live
+        appTimerCounter.handleStartTimer();
+      }
+    } else if (this.streamStatus === 'end' && appTimerCounter) {
+      appTimerCounter.handleEndTimer();
+
+      //when loaded on first time, if the stream has already ended, will get the previous stream duration
+      if (this.startTime && this.endTime) {
+        const startTime = new Date(this.startTime).getTime();
+        const endTime = new Date(this.endTime).getTime();
+        const substractTime = endTime - startTime;
+        appTimerCounter.handleFormatTime(substractTime);
+      }
+    }
   }
 
   render() {
@@ -134,14 +175,18 @@ export class AppInformationPanel extends LitElement {
             ? html`
                 <div class="lozenge-wrapper">
                   <app-lozenge class="lozenge-live">LIVE</app-lozenge>
-                  <app-lozenge>00:00:00</app-lozenge>
+                  <app-lozenge
+                    ><app-timer-counter></app-timer-counter
+                  ></app-lozenge>
                 </div>
               `
             : this.streamStatus === 'end'
             ? html`
                 <div class="lozenge-wrapper">
                   <app-lozenge class="lozenge-ended">Live Ended</app-lozenge>
-                  <app-lozenge>00:30:00</app-lozenge>
+                  <app-lozenge
+                    ><app-timer-counter></app-timer-counter
+                  ></app-lozenge>
                 </div>
               `
             : html`

--- a/src/features/streamer/studio/app-studio.js
+++ b/src/features/streamer/studio/app-studio.js
@@ -194,6 +194,8 @@ export class AppStudio extends LitElement {
             heading=${this.heading}
             description=${this.description}
             streamStatus=${this.streamStatus}
+            startTime=${this.startTime}
+            endTime=${this.endTime}
           ></app-information-panel>
         </div>
         <div class="action-panel">

--- a/src/features/viewer/room/app-information-panel.js
+++ b/src/features/viewer/room/app-information-panel.js
@@ -112,15 +112,18 @@ export class AppInformationPanel extends LitElement {
     /** @type {string} */
     this.description = '';
     /** @type {StreamStatusType} */
-    this.streamStatus = 'preparing';
+    this.streamStatus = 'upcoming';
     /** @type {string | undefined} */
     this.endTime = undefined;
     /** @type {string | undefined} */
     this.startTime = undefined;
   }
 
+  /**
+   * @param {{ has: (arg0: string) => any; }} changedProperties changed properties names
+   */
   updated(changedProperties) {
-    //check for the streamState changes from handleStreamState method
+    //check for the streamState changes
     if (changedProperties.has('streamStatus')) {
       this.handleTimer();
     }
@@ -128,11 +131,9 @@ export class AppInformationPanel extends LitElement {
 
   handleTimer() {
     const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
-    console.log('tes viewer', appTimerCounter.handleStartTimer());
-    console.log('cek status viewer', this.streamStatus);
 
     if (this.streamStatus === 'live' && appTimerCounter) {
-      //when the stream is live but the user accidentally reload the page, the timer will get the time when the stream started
+      //when the stream is live but the user just reload the page, the timer will get the time when the stream started
       if (this.startTime) {
         const startTime = new Date(this.startTime).getTime();
         appTimerCounter.handleStartTimer(startTime);
@@ -148,6 +149,14 @@ export class AppInformationPanel extends LitElement {
         const startTime = new Date(this.startTime).getTime();
         const endTime = new Date(this.endTime).getTime();
         const substractTime = endTime - startTime;
+        appTimerCounter.handleFormatTime(substractTime);
+      }
+
+      //when loaded on first time, if the stream hasn't ended yet (still on going), will get the stream duration up until now
+      if (this.startTime && !this.endTime) {
+        const startTime = new Date(this.startTime).getTime();
+        const timeNow = Date.now();
+        const substractTime = timeNow - startTime;
         appTimerCounter.handleFormatTime(substractTime);
       }
     }

--- a/src/features/viewer/room/app-information-panel.js
+++ b/src/features/viewer/room/app-information-panel.js
@@ -2,6 +2,7 @@ import { html, LitElement, css } from 'lit';
 import '../../shared/ui/app-viewer-count.js';
 import '../../shared/ui/app-lozenge.js';
 import '../../shared/ui/app-timer-counter.js';
+import { handleTimer } from '../../shared/modules/handle-timer.js';
 
 /**
  * @typedef {import('./app-viewer-room.js').StreamStatusType} StreamStatusType
@@ -125,40 +126,14 @@ export class AppInformationPanel extends LitElement {
   updated(changedProperties) {
     //check for the streamState changes
     if (changedProperties.has('streamStatus')) {
-      this.handleTimer();
-    }
-  }
-
-  handleTimer() {
-    const appTimerCounter = this.renderRoot.querySelector('app-timer-counter');
-
-    if (this.streamStatus === 'live' && appTimerCounter) {
-      //when the stream is live but the user just reload the page, the timer will get the time when the stream started
-      if (this.startTime) {
-        const startTime = new Date(this.startTime).getTime();
-        appTimerCounter.handleStartTimer(startTime);
-      } else {
-        //we don't need start time param when the stream is just started to live
-        appTimerCounter.handleStartTimer();
-      }
-    } else if (this.streamStatus === 'end' && appTimerCounter) {
-      appTimerCounter.handleEndTimer();
-
-      //when loaded on first time, if the stream has already ended, will get the previous stream duration
-      if (this.startTime && this.endTime) {
-        const startTime = new Date(this.startTime).getTime();
-        const endTime = new Date(this.endTime).getTime();
-        const substractTime = endTime - startTime;
-        appTimerCounter.handleFormatTime(substractTime);
-      }
-
-      //when loaded on first time, if the stream hasn't ended yet (still on going), will get the stream duration up until now
-      if (this.startTime && !this.endTime) {
-        const startTime = new Date(this.startTime).getTime();
-        const timeNow = Date.now();
-        const substractTime = timeNow - startTime;
-        appTimerCounter.handleFormatTime(substractTime);
-      }
+      const appTimerCounter =
+        this.renderRoot.querySelector('app-timer-counter');
+      handleTimer(
+        appTimerCounter,
+        this.streamStatus,
+        this.startTime,
+        this.endTime
+      );
     }
   }
 

--- a/src/features/viewer/room/app-viewer-room.js
+++ b/src/features/viewer/room/app-viewer-room.js
@@ -121,7 +121,6 @@ export class AppViewerRoom extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    console.log('cek dpn end time', this.endTime);
     if (this.startTime && !this.endTime) {
       this.streamStatus = 'live';
     } else if (this.startTime && this.endTime) {

--- a/src/features/viewer/room/app-viewer-room.js
+++ b/src/features/viewer/room/app-viewer-room.js
@@ -1,4 +1,5 @@
 import { css, html, LitElement } from 'lit';
+import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
 import './app-video-panel.js';
 import './app-information-panel.js';
 import './app-activity-panel.js';
@@ -97,7 +98,8 @@ export class AppViewerRoom extends LitElement {
     hlsManifest: { type: String },
     dashManifest: { type: String },
     startTime: { type: String },
-    endTime: { type: String }
+    endTime: { type: String },
+    streamStatus: { type: String }
   };
 
   constructor() {
@@ -141,6 +143,8 @@ export class AppViewerRoom extends LitElement {
             heading=${this.heading}
             description=${this.description}
             streamStatus=${this.streamStatus}
+            startTime=${this.startTime}
+            endTime=${this.endTime}
           ></app-information-panel>
         </div>
         <div class="activity-panel">

--- a/src/features/viewer/room/app-viewer-room.js
+++ b/src/features/viewer/room/app-viewer-room.js
@@ -1,5 +1,4 @@
 import { css, html, LitElement } from 'lit';
-import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
 import './app-video-panel.js';
 import './app-information-panel.js';
 import './app-activity-panel.js';
@@ -122,6 +121,7 @@ export class AppViewerRoom extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    console.log('cek dpn end time', this.endTime);
     if (this.startTime && !this.endTime) {
       this.streamStatus = 'live';
     } else if (this.startTime && this.endTime) {

--- a/src/pages/streaming/studio/[streamid].js
+++ b/src/pages/streaming/studio/[streamid].js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk-test/stream';
 import { validation } from '../../../features/auth/validation.js';
 
 const StudioStreamingPage = (properties) => {

--- a/src/pages/streaming/studio/[streamid].js
+++ b/src/pages/streaming/studio/[streamid].js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk-test/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
 import { validation } from '../../../features/auth/validation.js';
 
 const StudioStreamingPage = (properties) => {

--- a/src/pages/streaming/watch/[streamid].js
+++ b/src/pages/streaming/watch/[streamid].js
@@ -2,7 +2,14 @@ import { html } from 'lit';
 import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
 
 const WatchStreamingPage = (properties) => {
-  const { heading, description, hlsManifest, dashManifest } = properties;
+  const {
+    heading,
+    description,
+    hlsManifest,
+    dashManifest,
+    startTime,
+    endTime
+  } = properties;
 
   return html`
     <app-viewer-room
@@ -10,6 +17,8 @@ const WatchStreamingPage = (properties) => {
       description=${description}
       hlsManifest=${hlsManifest}
       dashManifest=${dashManifest}
+      startTime=${startTime}
+      endTime=${endTime}
     >
     </app-viewer-room>
   `;


### PR DESCRIPTION
**Descritption**
This is related to issue #27 , that it's good to have if we could activate timer counter on streamer page & viewer page too.

**Implementation**
- Make a timer counter functionality component called `app-timer-counter` to show the final duration time.
- Make a reusable handle timer function (called `handleTimer`) to process which function should be executed to get duration time based on `startTime`, `endTime`, `streamStatus`.
- Add the timer counter to `streaming/studio/{streamId}` page => on `app-information-panel` streamer component
- Add the timer counter to `streaming/watch/{streamId}` page => on `app-information-panel` viewer component

<img width="1357" alt="Screen Shot 2022-10-25 at 16 44 26" src="https://user-images.githubusercontent.com/102952824/197754640-7e7d5cb3-a8da-4f56-afa2-6c6ddf0c5281.png">
<img width="1417" alt="Screen Shot 2022-10-25 at 16 23 06" src="https://user-images.githubusercontent.com/102952824/197754663-511ea070-a3a0-4e7a-8d33-dd73c38e5371.png">

**Some additional notes :** 
- The timer counter functionality component called `app-timer-counter` codes same with our studio codes (I think no need to be improved by now).
- I modified a bit on handle timer function (called `handleTimer`) to add condition `startTime && !endTime` because this condition will be execute on viewer watch page if the stream has been live for some time. So the timer counter of viewer will be same as the streamer too.
- On the `streaming/studio/{streamId}` if being refreshed page while streaming then back start from preparing status again so the counter won't show.
