### PR TITLE
Fix : API Key from Snake Case into Camel Case

### DIFF
--- a/src/pages/api/stream/[name].js
+++ b/src/pages/api/stream/[name].js
@@ -34,7 +34,7 @@ const handler = async (request, reply) => {
    */
   let config = {
     // eslint-disable-next-line camelcase
-    api_key: process.env.API_KEY
+    apiKey: process.env.API_KEY
   };
 
   const inliveApp = InliveApp.init(config);

--- a/src/pages/api/stream/[name].js
+++ b/src/pages/api/stream/[name].js
@@ -24,7 +24,7 @@ const handler = async (request, reply) => {
 
   /**
    * @typedef Config
-   * @property {string} api_key - A string of key that will be used to access inLive protected API
+   * @property {string} apiKey - A string of key that will be used to access inLive protected API
    */
 
   /**


### PR DESCRIPTION
**Description**
Based on Inlive [JS SDK PR #36](https://github.com/inlivedev/inlive-js-sdk/pull/36) that already using camel case for initialization API Key, then we need to adjust our essential kit too to use a camel case too for inputing the API Key for initialization process.

**Implementation**
- Convert `api_key` to be `apiKey`