### PR TITLE
Upgrade Inlive JS SDK Version to be 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fastify/cookie": "^8.3.0",
         "@fastify/jwt": "^6.3.2",
         "@fastify/static": "^6.5.0",
-        "@inlivedev/inlive-js-sdk": "^0.2.0",
+        "@inlivedev/inlive-js-sdk": "^0.2.1",
         "@lit-labs/ssr": "2.2.3",
         "dotenv": "^16.0.3",
         "fastify": "^4.8.1",
@@ -314,9 +314,9 @@
       "dev": true
     },
     "node_modules/@inlivedev/inlive-js-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.2.0.tgz",
-      "integrity": "sha512-m8YpslmZrd1qUuVydQC/x1X1Hm3q46FIP+36wzmbdXQshGfsT/v/NXvyW4lw2GLgjM9L29HocHdvVmiP3cIr3w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.2.1.tgz",
+      "integrity": "sha512-tgBUYLyXi856M6TzEn9um8CG9YgkuthEQFpkv3iDR6asZ4rdmZTLQ4YAaF+VVtbI3JQlhkxAiOotSqgnan84qg==",
       "dependencies": {
         "camelcase-keys": "^8.0.2",
         "node-fetch": "3.2.10",
@@ -4985,9 +4985,9 @@
       "dev": true
     },
     "@inlivedev/inlive-js-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.2.0.tgz",
-      "integrity": "sha512-m8YpslmZrd1qUuVydQC/x1X1Hm3q46FIP+36wzmbdXQshGfsT/v/NXvyW4lw2GLgjM9L29HocHdvVmiP3cIr3w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.2.1.tgz",
+      "integrity": "sha512-tgBUYLyXi856M6TzEn9um8CG9YgkuthEQFpkv3iDR6asZ4rdmZTLQ4YAaF+VVtbI3JQlhkxAiOotSqgnan84qg==",
       "requires": {
         "camelcase-keys": "^8.0.2",
         "node-fetch": "3.2.10",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@fastify/cookie": "^8.3.0",
     "@fastify/jwt": "^6.3.2",
     "@fastify/static": "^6.5.0",
-    "@inlivedev/inlive-js-sdk": "^0.2.0",
+    "@inlivedev/inlive-js-sdk": "^0.2.1",
     "@lit-labs/ssr": "2.2.3",
     "dotenv": "^16.0.3",
     "fastify": "^4.8.1",


### PR DESCRIPTION
**Description**
Since we've upgrade the inLive JS SDK version into `0.2.1`, then we need to upgrade on this essential kit as well because we'll be using camelCase on the initialization of API key.

**Implementation**
- Upgrade inLive JS SDK version to be `0.2.1`