### PR TITLE
Update : Import SDK Link

### DIFF
--- a/src/features/shared/modules/initialization.js
+++ b/src/features/shared/modules/initialization.js
@@ -1,4 +1,4 @@
-import { InliveApp } from '@inlivedev/inlive-js-sdk-dev/app';
+import { InliveApp } from '@inlivedev/inlive-js-sdk';
 
 export const initialization = () => {
   /**

--- a/src/features/streamer/studio/app-stream-capturer.js
+++ b/src/features/streamer/studio/app-stream-capturer.js
@@ -1,6 +1,6 @@
 import { LitElement } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
-import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
+import { InliveStream } from '@inlivedev/inlive-js-sdk';
+import { InliveEvent } from '@inlivedev/inlive-js-sdk';
 import { fetchHttp } from '../../shared/modules/fetch-http.js';
 
 /**

--- a/src/features/streamer/studio/app-studio.js
+++ b/src/features/streamer/studio/app-studio.js
@@ -1,5 +1,5 @@
 import { html, css, LitElement } from 'lit';
-import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
+import { InliveEvent } from '@inlivedev/inlive-js-sdk';
 import './app-action-panel.js';
 import './app-video-panel.js';
 import './app-information-panel.js';

--- a/src/pages/api/stream/[name].js
+++ b/src/pages/api/stream/[name].js
@@ -1,4 +1,4 @@
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk';
 import { validation } from '../../../features/auth/validation.js';
 import { initialization } from '../../../features/shared/modules/initialization.js';
 

--- a/src/pages/streaming/embed/[streamid].js
+++ b/src/pages/streaming/embed/[streamid].js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk';
 import { initialization } from '../../../features/shared/modules/initialization.js';
 
 const EmbedStreamingPage = (properties) => {

--- a/src/pages/streaming/preview/[streamid].js
+++ b/src/pages/streaming/preview/[streamid].js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk';
 import { initialization } from '../../../features/shared/modules/initialization.js';
 
 const PreviewLiveStream = (

--- a/src/pages/streaming/studio/[streamid].js
+++ b/src/pages/streaming/studio/[streamid].js
@@ -46,8 +46,6 @@ export const getServerSideProps = async (request, reply) => {
   }
 
   const inliveApp = initialization();
-
-  console.log('cek', typeof streamId);
   const streamResponse = await InliveStream.getStream(inliveApp, streamId);
   let streamData = {};
 

--- a/src/pages/streaming/studio/[streamid].js
+++ b/src/pages/streaming/studio/[streamid].js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk';
 import { validation } from '../../../features/auth/validation.js';
 import { initialization } from '../../../features/shared/modules/initialization.js';
 
@@ -47,6 +47,7 @@ export const getServerSideProps = async (request, reply) => {
 
   const inliveApp = initialization();
 
+  console.log('cek', typeof streamId);
   const streamResponse = await InliveStream.getStream(inliveApp, streamId);
   let streamData = {};
 

--- a/src/pages/streaming/watch/[streamid].js
+++ b/src/pages/streaming/watch/[streamid].js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { InliveStream } from '@inlivedev/inlive-js-sdk/stream';
+import { InliveStream } from '@inlivedev/inlive-js-sdk';
 import { initialization } from '../../../features/shared/modules/initialization.js';
 
 const WatchStreamingPage = (properties) => {


### PR DESCRIPTION
**Description**
According to the [updated documentation of SDK](https://github.com/inlivedev/inlive-js-sdk/tree/feat/build-bundled-sdk), we need to change our way of import InLive SDK because we will bundled our InLive SDK (not import the module separately per modules).

**Implementation**
- Change from `import { InliveApp } from '@inlivedev/inlive-js-sdk/app';` to be `import { InliveApp } from '@inlivedev/inlive-js-sdk';` (as an example).